### PR TITLE
add source directive to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 ASpaceGems.setup if defined? ASpaceGems
+source 'https://rubygems.org'
 
 gem "write_xlsx", "1.01.0"


### PR DESCRIPTION
I think a `source` directive is needed for users who don't already have this gem - probably not an issue before because the plugin depended on another with the same dependency.